### PR TITLE
CheckSubmodules script

### DIFF
--- a/Tools/CheckSubmodules.ps1
+++ b/Tools/CheckSubmodules.ps1
@@ -43,7 +43,6 @@ function Get-SubmoduleActualCommit {
     }
 }
 
-# Get the repository root from the global context
 $repoRoot = Split-Path -Parent $global:context.ProjectInfos.UProjectPath
 Push-Location $repoRoot
 

--- a/Tools/CheckSubmodules.ps1
+++ b/Tools/CheckSubmodules.ps1
@@ -1,3 +1,5 @@
+Import-Module -Name ( Resolve-Path( Join-Path -Path ( $PSScriptRoot ) -ChildPath "..\UEPoshScripts.psm1" ) ) -ErrorAction Stop -Force
+
 function Get-SubmoduleStatus {
     param (
         [string[]]$StatusOutput
@@ -41,8 +43,8 @@ function Get-SubmoduleActualCommit {
     }
 }
 
-$scriptPath = $PSScriptRoot
-$repoRoot = Resolve-Path (Join-Path $scriptPath "..\..")
+# Get the repository root from the global context
+$repoRoot = Split-Path -Parent $global:context.ProjectInfos.UProjectPath
 Push-Location $repoRoot
 
 try {

--- a/Tools/CheckSubmodules.ps1
+++ b/Tools/CheckSubmodules.ps1
@@ -1,0 +1,102 @@
+function Get-SubmoduleStatus {
+    param (
+        [string[]]$StatusOutput
+    )
+
+    $submodules = @{}
+    foreach ($line in $StatusOutput) {
+        if ($line -match '^\s*(\w+)\s+([^\s]+)\s+\(?(.*?)\)?$') {
+            $commit = $matches[1]
+            $path = $matches[2]
+            $submodules[$path] = $commit
+        }
+    }
+    return $submodules
+}
+
+function Get-DevelopSubmodules {
+    $submodules = @{}
+    $submodulePaths = git config --file .gitmodules --get-regexp path | ForEach-Object { ($_ -split "\s+")[1] }
+
+    foreach ($path in $submodulePaths) {
+        $commit = git rev-parse develop:$path
+        if ($commit) {
+            $submodules[$path] = $commit
+        }
+    }
+    return $submodules
+}
+
+function Get-SubmoduleActualCommit {
+    param (
+        [string]$SubmodulePath
+    )
+
+    Push-Location $SubmodulePath
+    try {
+        return git rev-parse HEAD
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+$scriptPath = $PSScriptRoot
+$repoRoot = Resolve-Path (Join-Path $scriptPath "..\..")
+Push-Location $repoRoot
+
+try {
+    $currentBranch = git rev-parse --abbrev-ref HEAD
+
+    $currentStatus = git submodule status
+    $currentSubmodules = Get-SubmoduleStatus $currentStatus
+
+    Write-Host "Getting develop branch submodule information..." -ForegroundColor Cyan
+    $developSubmodules = Get-DevelopSubmodules
+
+    Write-Host "`nSubmodule Comparison Results:`n" -ForegroundColor Cyan
+    Write-Host ("Format: [Path] Current Branch ({0}) -> Develop`n" -f $currentBranch) -ForegroundColor Cyan
+
+    $mismatchCount = 0
+    foreach ($path in $currentSubmodules.Keys) {
+        $currentCommit = $currentSubmodules[$path]
+        $developCommit = $developSubmodules[$path]
+        $actualCommit = Get-SubmoduleActualCommit $path
+
+        $isRecordMatch = $currentCommit -eq $developCommit
+        $isActualMatch = $actualCommit.StartsWith($currentCommit)
+
+        if ($isRecordMatch -and $isActualMatch) {
+            Write-Host "$path" -NoNewline -ForegroundColor Green
+            Write-Host ": MATCH ($currentCommit)"
+        } else {
+            $mismatchCount++
+            Write-Host "$path" -NoNewline -ForegroundColor Red
+            Write-Host ": DIFFERENT"
+
+            if (-not $isActualMatch) {
+                Write-Host "  Working directory is at different commit!" -ForegroundColor Yellow
+                Write-Host ("  Expected: {0}" -f $currentCommit)
+                Write-Host ("  Actual:   {0}" -f $actualCommit)
+            }
+
+            if (-not $isRecordMatch) {
+                Write-Host ("  {0}: {1}" -f $currentBranch, $currentCommit)
+                Write-Host ("  develop: {0}" -f $developCommit)
+            }
+        }
+    }
+
+    Write-Host "`nSummary:" -ForegroundColor Cyan
+    if ($mismatchCount -eq 0) {
+        Write-Host "All submodules match develop branch and are at their expected commits! ✓" -ForegroundColor Green
+    } else {
+        Write-Host ("Found {0} submodule(s) with issues." -f $mismatchCount) -ForegroundColor Yellow
+    }
+}
+catch {
+    Write-Host "An error occurred: $_" -ForegroundColor Red
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
Adds a PowerShell script that compares submodule states between the current branch and develop. The script:

- Shows differences between expected and actual submodule commits
- Checks both recorded state in git and actual working directory state
- Uses git rev-parse to get commit references
- Prints a summary on STDOUT

Useful for catching unintended submodule changes before merging to develop.